### PR TITLE
1-block-github-workflow-when-a-php-package-is-outdated

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,4 +44,4 @@ jobs:
         run: docker-compose run --rm composer run check
 
       - name: Package version check
-        run: docker-compose run --rm composer outdated --direct
+        run: docker-compose run --rm composer run updates

--- a/README.md
+++ b/README.md
@@ -278,5 +278,5 @@ composer run test
 composer run analyse
 composer run check
 composer run lint
-composer outdated --direct
+composer run updates
 ```

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
         "lint": "php-cs-fixer fix --diff --using-cache=no --allow-risky=yes --dry-run",
         "format": "php-cs-fixer --using-cache=no --allow-risky=yes fix",
         "install-checker": "local-php-security-checker-installer",
-        "check": "local-php-security-checker"
+        "check": "local-php-security-checker",
+        "updates": "composer outdated --strict --direct"
     },
     "require": {
         "laravel/framework": "8.*"


### PR DESCRIPTION
## Added

- Github workflow at step "Composer package check" will stop if a PHP package is outdated

## Fixed

N/A.

## Breaking

N/A.