### PR TITLE
10-find-eloquent-model-by-slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `Sluggable::findBySlug(string)` and `Sluggable::findBySlugOrFail(string)` methods ([#10](https://github.com/khalyomede/laravel-eloquent-uuid-slug/issues/10)).
+
+
 ## [0.3.0] 2022-02-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -253,6 +253,22 @@ Route::get("/cart/{cart}", function(string $identifier) {
 });
 ```
 
+The `Sluggable::findBySlug()` and `Sluggable::findBySlugOrFail()` methods also exist as a shorthand:
+
+```php
+// routes/web.php
+
+use App\Models\Cart;
+use Illuminate\Support\Facades\Route;
+
+Route::get("/cart/{cart}", function(string $identifier) {
+  $cart = Cart::findBySlugOrFail($identifier);
+  $cart = Cart::findBySlug($identifier);
+
+  // $cart ready to be used
+});
+```
+
 ## Compatibility table
 
 The table below shows the compatibility across Laravel, PHP and this package **current version**. For the compatibility regarding this package previous version, please browse another tag.

--- a/src/Sluggable.php
+++ b/src/Sluggable.php
@@ -39,6 +39,16 @@ trait Sluggable
         return $query->where($this->slugColumn(), $slug);
     }
 
+    public static function findBySlug(string $slug): ?self
+    {
+        return self::withSlug($slug)->first();
+    }
+
+    public static function findBySlugOrFail(string $slug): self
+    {
+        return self::withSlug($slug)->firstOrFail();
+    }
+
     public static function addSlugColumn(Blueprint $table): ColumnDefinition
     {
         $instance = new static();

--- a/tests/Feature/SluggableTest.php
+++ b/tests/Feature/SluggableTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Routing\Middleware\SubstituteBindings;
@@ -116,5 +117,32 @@ final class SluggableTest extends TestCase
 
         $this->assertEquals($cart->id, $found);
         $this->assertNull($notFound);
+    }
+
+    public function testItCanFindModelBySlug(): void
+    {
+        $cart = Cart::factory()
+            ->create();
+
+        self::assertNull(Cart::findBySlug($this->faker->slug()));
+        self::assertInstanceOf(Cart::class, Cart::findBySlug($cart->code));
+    }
+
+    public function testItCanFindModelBySlugOrThrowsException(): void
+    {
+        $code = $this->faker->slug();
+
+        Cart::factory()
+            ->create([
+                "code" => $code,
+            ]);
+
+        $cart = Cart::findBySlugOrFail($code);
+
+        self::assertEquals($code, $cart->code);
+
+        $this->expectException(ModelNotFoundException::class);
+
+        Cart::findBySlugOrFail($this->faker->slug());
     }
 }


### PR DESCRIPTION
## Added

- New `Sluggable::findBySlug(string)` method, similar to `Model::find(mixed)`
- New `Sluggable::findBySlugOrFail(string)` method, similar to `Model::findOrFail(mixed)`

## Fixed

N/A

## Breaking

N/A