### PR TITLE
#2 add dropping slug column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - New `Sluggable::findBySlug(string)` and `Sluggable::findBySlugOrFail(string)` methods ([#10](https://github.com/khalyomede/laravel-eloquent-uuid-slug/issues/10)).
+- New `Sluggable::dropSlugColumn(Blueprint)`, `Sluggable::addUnconstrainedSlugColumn(Blueprint)` and `Sluggable::fillEmptySlugs()` methods ([#2]).
 
 
 ## [0.3.0] 2022-02-12

--- a/README.md
+++ b/README.md
@@ -117,6 +117,35 @@ final class CreateCartsTable extends Migration
 }
 ```
 
+If you do not want the `Sluggable::addSlugColumn(Blueprint)` to add SQL constraints (unique index and non nullable column), use its counterpart method `Sluggable::addUnconstrainedSlugColumn(Blueprint)`.
+
+```php
+use App\Models\Cart;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+final class CreateCartsTable extends Migration
+{
+  public function up(): void
+  {
+    Schema::create('carts', function (Blueprint $table): void {
+      $table->id();
+      $table->string('name');
+
+      Cart::addUnconstrainedSlugColumn($table);
+
+      $table->timestamps();
+    });
+  }
+
+  public function down(): void
+  {
+    Schema::drop('carts');
+  }
+}
+```
+
 ## Examples
 
 - [1. Configure the slug column name](#1-configure-the-slug-column-name)
@@ -124,6 +153,7 @@ final class CreateCartsTable extends Migration
 - [3. Custom route model binding for specific routes](#3-custom-route-model-binding-for-specific-routes)
 - [4. Customize the slug column in your migration](#4-customize-the-slug-column-in-your-migration)
 - [5. Retreive a model by its slug](#5-retreive-a-model-by-its-slug)
+- [6. Dropping the slug column](#6-dropping-the-slug-column)
 
 ### 1. Configure the slug column name
 
@@ -267,6 +297,39 @@ Route::get("/cart/{cart}", function(string $identifier) {
 
   // $cart ready to be used
 });
+```
+
+### 6. Dropping the slug column
+
+You can use `Sluggable::dropSlugColumn(Blueprint)` when you want to drop only the slug column on an existing table. Please follow the complete instructions on the "down" method since there is some gotchas to deal with.
+
+```php
+use App\Models\Cart;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+final class DropSlugColumnOnCartsTable extends Migration
+{
+  public function up(): void
+  {
+    Schema::create('carts', function (Blueprint $table): void {
+      Cart::dropSlugColumn($table);
+    });
+  }
+
+  public function down(): void
+  {
+    Schema::table('posts', function (Blueprint $table): void {
+      Cart::addUnconstrainedSlugColumn($table);
+    });
+
+    Schema::table('posts', function (Blueprint $table): void {
+      Cart::fillEmptySlugs();
+      Cart::constrainSlugColumn($table);
+    });
+  }
+}
 ```
 
 ## Compatibility table

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
         "nunomaduro/collision": "6.1.0",
         "friendsofphp/php-cs-fixer": "3.6.0",
         "thibautselingue/local-php-security-checker-installer": "1.0.3",
-        "nunomaduro/larastan": "2.0.1"
+        "nunomaduro/larastan": "2.0.1",
+        "doctrine/dbal": "3.3.4"
     },
     "scripts": {
         "test": "testbench package:test",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c3a3a40f2bad9b337c967e7147219cf8",
+    "content-hash": "1bdbe7e6b4450b8f46db4e54967f197a",
     "packages": [
         {
             "name": "brick/math",
@@ -4508,6 +4508,353 @@
                 "source": "https://github.com/doctrine/annotations/tree/1.13.2"
             },
             "time": "2021-08-05T19:00:23+00:00"
+        },
+        {
+            "name": "doctrine/cache",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/cache.git",
+                "reference": "331b4d5dbaeab3827976273e9356b3b453c300ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/331b4d5dbaeab3827976273e9356b3b453c300ce",
+                "reference": "331b4d5dbaeab3827976273e9356b3b453c300ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/common": ">2.2,<2.4"
+            },
+            "require-dev": {
+                "alcaeus/mongo-php-adapter": "^1.1",
+                "cache/integration-tests": "dev-master",
+                "doctrine/coding-standard": "^8.0",
+                "mongodb/mongodb": "^1.1",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
+                "predis/predis": "~1.0",
+                "psr/cache": "^1.0 || ^2.0 || ^3.0",
+                "symfony/cache": "^4.4 || ^5.2 || ^6.0@dev",
+                "symfony/var-exporter": "^4.4 || ^5.2 || ^6.0@dev"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "Required to use legacy MongoDB driver"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Cache library is a popular cache implementation that supports many different drivers such as redis, memcache, apc, mongodb and others.",
+            "homepage": "https://www.doctrine-project.org/projects/cache.html",
+            "keywords": [
+                "abstraction",
+                "apcu",
+                "cache",
+                "caching",
+                "couchdb",
+                "memcached",
+                "php",
+                "redis",
+                "xcache"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/cache/issues",
+                "source": "https://github.com/doctrine/cache/tree/2.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fcache",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-07-17T14:49:29+00:00"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "3.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "83f779beaea1893c0bece093ab2104c6d15a7f26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/83f779beaea1893c0bece093ab2104c6d15a7f26",
+                "reference": "83f779beaea1893c0bece093ab2104c6d15a7f26",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2",
+                "doctrine/cache": "^1.11|^2.0",
+                "doctrine/deprecations": "^0.5.3",
+                "doctrine/event-manager": "^1.0",
+                "php": "^7.3 || ^8.0",
+                "psr/cache": "^1|^2|^3",
+                "psr/log": "^1|^2|^3"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "9.0.0",
+                "jetbrains/phpstorm-stubs": "2021.1",
+                "phpstan/phpstan": "1.4.6",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "phpunit/phpunit": "9.5.16",
+                "psalm/plugin-phpunit": "0.16.1",
+                "squizlabs/php_codesniffer": "3.6.2",
+                "symfony/cache": "^5.2|^6.0",
+                "symfony/console": "^2.7|^3.0|^4.0|^5.0|^6.0",
+                "vimeo/psalm": "4.22.0"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "bin": [
+                "bin/doctrine-dbal"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\DBAL\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+            "homepage": "https://www.doctrine-project.org/projects/dbal.html",
+            "keywords": [
+                "abstraction",
+                "database",
+                "db2",
+                "dbal",
+                "mariadb",
+                "mssql",
+                "mysql",
+                "oci8",
+                "oracle",
+                "pdo",
+                "pgsql",
+                "postgresql",
+                "queryobject",
+                "sasql",
+                "sql",
+                "sqlite",
+                "sqlserver",
+                "sqlsrv"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/dbal/issues",
+                "source": "https://github.com/doctrine/dbal/tree/3.3.4"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdbal",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-03-20T18:37:29+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "v0.5.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "9504165960a1f83cc1480e2be1dd0a0478561314"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/9504165960a1f83cc1480e2be1dd0a0478561314",
+                "reference": "9504165960a1f83cc1480e2be1dd0a0478561314",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1|^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0|^7.0|^8.0",
+                "phpunit/phpunit": "^7.0|^8.0|^9.0",
+                "psr/log": "^1.0"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "lib/Doctrine/Deprecations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/v0.5.3"
+            },
+            "time": "2021-03-21T12:59:47+00:00"
+        },
+        {
+            "name": "doctrine/event-manager",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/event-manager.git",
+                "reference": "41370af6a30faa9dc0368c4a6814d596e81aba7f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/41370af6a30faa9dc0368c4a6814d596e81aba7f",
+                "reference": "41370af6a30faa9dc0368c4a6814d596e81aba7f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/common": "<2.9@dev"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^6.0",
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "lib/Doctrine/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "The Doctrine Event Manager is a simple PHP event system that was built to be used with the various Doctrine projects.",
+            "homepage": "https://www.doctrine-project.org/projects/event-manager.html",
+            "keywords": [
+                "event",
+                "event dispatcher",
+                "event manager",
+                "event system",
+                "events"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/event-manager/issues",
+                "source": "https://github.com/doctrine/event-manager/tree/1.1.x"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fevent-manager",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-29T18:28:51+00:00"
         },
         {
             "name": "doctrine/instantiator",

--- a/tests/Models/Post.php
+++ b/tests/Models/Post.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Khalyomede\EloquentUuidSlug\Sluggable;
+use Tests\Database\Factories\PostFactory;
+
+final class Post extends Model
+{
+    use HasFactory;
+    use Sluggable;
+
+    protected $guarded = [];
+
+    protected static function newFactory(): PostFactory
+    {
+        return PostFactory::new();
+    }
+}

--- a/tests/database/factories/PostFactory.php
+++ b/tests/database/factories/PostFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Tests\Models\Post;
+
+/**
+ * @extends Factory<Post>
+ */
+final class PostFactory extends Factory
+{
+    protected $model = Post::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'title' => $this->faker->name(),
+        ];
+    }
+}

--- a/tests/database/migrations/202204031153_create_posts_table.php
+++ b/tests/database/migrations/202204031153_create_posts_table.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Database\Migrations;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Tests\Models\Post;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('posts', function (Blueprint $table): void {
+            $table->id();
+
+            Post::addSlugColumn($table);
+
+            $table->string('title');
+            $table->timestamps();
+        });
+
+        // To test dropping the column works well with existing data on the next migration.
+        Post::factory()
+            ->count(10)
+            ->create();
+    }
+
+    public function down(): void
+    {
+        Schema::drop('posts');
+    }
+};

--- a/tests/database/migrations/202204031155_drop_slug_column_on_posts_table copy.php
+++ b/tests/database/migrations/202204031155_drop_slug_column_on_posts_table copy.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Database\Migrations;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Tests\Models\Post;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::table('posts', function (Blueprint $table): void {
+            Post::dropSlugColumn($table);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('posts', function (Blueprint $table): void {
+            Post::addUnconstrainedSlugColumn($table);
+        });
+
+        Schema::table('posts', function (Blueprint $table): void {
+            Post::fillEmptySlugs();
+            Post::constrainSlugColumn($table);
+        });
+    }
+};


### PR DESCRIPTION
## Added

- New `Sluggable::dropSlugColumn(Blueprint)` to drop the slug column within a migration
- New `Sluggable::addUnconstrainedSlugColumn(Blueprint)` to add the slug column without not null and unique SQL constraints within a migration
- New `Sluggable::fillEmptySlugs()` to fill the slug column with slugs when this column has a null value

## Fixed

N/A

## Breaking

N/A