### PR TITLE
15-calling-model-replicate-save-raise-an-exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- You can now call `$model->replicate()` without this method call raising an exception ([#15](https://github.com/khalyomede/laravel-eloquent-uuid-slug/issues/15)).
+
 ## [0.5.0] 2022-06-06
 
 ### Added

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5cdeee93957bfb209acc181c01cd8187",
+    "content-hash": "0ba205942519c7954bc2f99e0107fc13",
     "packages": [
         {
             "name": "brick/math",
@@ -572,16 +572,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v9.16.0",
+            "version": "v9.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "dbad869e737542734c48d36d4cb87ee90455c4b8"
+                "reference": "091e287678ac723c591509ca6374e4ded4a99b1c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/dbad869e737542734c48d36d4cb87ee90455c4b8",
-                "reference": "dbad869e737542734c48d36d4cb87ee90455c4b8",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/091e287678ac723c591509ca6374e4ded4a99b1c",
+                "reference": "091e287678ac723c591509ca6374e4ded4a99b1c",
                 "shasum": ""
             },
             "require": {
@@ -747,7 +747,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-06-02T18:13:11+00:00"
+            "time": "2022-06-07T15:09:32+00:00"
         },
         {
             "name": "laravel/serializable-closure",

--- a/src/Sluggable.php
+++ b/src/Sluggable.php
@@ -41,6 +41,14 @@ trait Sluggable
         return $query->where($this->slugColumn(), $slug);
     }
 
+    /**
+     * Overriding Laravel's default.
+     */
+    public function replicate(array $except = null)
+    {
+        return parent::replicate(array_merge($except ?? [], [$this->slugColumn()]));
+    }
+
     public static function findBySlug(string $slug): ?self
     {
         return self::withSlug($slug)->first();

--- a/src/Sluggable.php
+++ b/src/Sluggable.php
@@ -43,6 +43,8 @@ trait Sluggable
 
     /**
      * Overriding Laravel's default.
+     *
+     * @param array<string>|null $except
      */
     public function replicate(array $except = null)
     {

--- a/tests/Feature/SluggableTest.php
+++ b/tests/Feature/SluggableTest.php
@@ -145,4 +145,17 @@ final class SluggableTest extends TestCase
 
         Cart::findBySlugOrFail($this->faker->slug());
     }
+
+    public function testCanReplicateSluggable(): void
+    {
+        $cart = Cart::factory()
+            ->create();
+
+        $newCart = $cart->replicate();
+        $newCart->save();
+
+        self::assertNotEquals($cart->id, $newCart->id);
+        self::assertNotEquals($cart->code, $newCart->code);
+        self::assertEquals($cart->name, $newCart->name);
+    }
 }


### PR DESCRIPTION
## Added

- `laravel/framework` version upgrade

## Fixed

- Calling `$model->replicate()->save()` will now work as expected (without raising a database duplicate error)

## Breaked

N/A

