### PR TITLE
18-do-not-rely-on-booted-method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking
+
+- The `Sluggable` trait does not exploits the `booted` method anymore. Tt uses `bootSluggable` now ([#18](https://github.com/khalyomede/laravel-eloquent-uuid-slug/issues/18)).
+
 ## [0.5.1] 2022-06-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ The goal of this package is to simplify at best this task for you.
 
 - This package relies on these methods **on your model**, and if you override them the logic might not be guarranteed to keep working:
   - [`public function getRouteKeyName()`](https://laravel.com/docs/8.x/routing#customizing-the-default-key-name)
-  - [`protected static function booted()`](https://laravel.com/docs/8.x/eloquent#defining-observers) (for the _creating_ event)
 
 ## Installation
 

--- a/src/Sluggable.php
+++ b/src/Sluggable.php
@@ -133,7 +133,7 @@ trait Sluggable
             });
     }
 
-    protected static function booted(): void
+    protected static function bootSluggable(): void
     {
         static::creating(function (self $model): void {
             $slugColumn = $model->slugColumn();

--- a/tests/database/factories/CartFactory.php
+++ b/tests/database/factories/CartFactory.php
@@ -18,7 +18,7 @@ final class CartFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => $this->faker->name(),
+            'name' => $this->faker->word(),
         ];
     }
 }


### PR DESCRIPTION
## Added

N/A

## Fixed

N/A

## Breaked

- The `Sluggable` trait now uses the `bootSluggable` method instead of `booted` on your model