### PR TITLE
20-new-first-by-slug-and-first-by-slug-or-fail-methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New methods `Sluggable::firstBySlug()` and `Sluggable::firstBySlugOrFail()` ([#20](https://github.com/khalyomede/laravel-eloquent-uuid-slug/issues/20)).
+
+### Fixed
+
+- Unable to chain Sluggable scopes after Built-in scopes ([#20](https://github.com/khalyomede/laravel-eloquent-uuid-slug/issues/20)).
+- Unable to call `Sluggable::findBySlug()` nor `Sluggable::findBySlugOrFail()` on HasMany relationship ([#23](https://github.com/khalyomede/laravel-eloquent-uuid-slug/issues/23)).
+
+### Breaked
+
+- If you customized the name of the slug column using `protected function slugColumn()`, change the visibility modifier from `protected` to `public` ([#22](https://github.com/khalyomede/laravel-eloquent-uuid-slug/issues/22)).
+
 ## [0.7.0] 2022-12-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Route::get("/cart/{cart}", function(string $identifier) {
 });
 ```
 
-The `Sluggable::findBySlug()` and `Sluggable::findBySlugOrFail()` methods also exist as a shorthand:
+The `Sluggable::findBySlug()`, `Sluggable::findBySlugOrFail()`, `Sluggable::firstBySlug()` or `Sluggable::firstBySlugOrFail()` methods also exist as a shorthand:
 
 ```php
 // routes/web.php
@@ -294,6 +294,8 @@ use Illuminate\Support\Facades\Route;
 Route::get("/cart/{cart}", function(string $identifier) {
   $cart = Cart::findBySlugOrFail($identifier);
   $cart = Cart::findBySlug($identifier);
+  $cart = Cart::where("id", ">=", 1)->firstBySlug($identifier);
+  $cart = Cart::where("id", ">=", 1)->firstBySlugOrFail($identifier);
 
   // $cart ready to be used
 });

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "test": "testbench package:test",
         "analyse": "phpstan analyse",
         "lint": "PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer fix --diff --using-cache=no --allow-risky=yes --dry-run",
-        "format": "php-cs-fixer --using-cache=no --allow-risky=yes fix",
+        "format": "PHP_CS_FIXER_IGNORE_ENV=1 php-cs-fixer --using-cache=no --allow-risky=yes fix",
         "check": "composer audit --locked --no-dev",
         "updates": "composer outdated --strict --direct",
         "scan": "rector process --dry-run",

--- a/rector.php
+++ b/rector.php
@@ -34,4 +34,6 @@ return static function (RectorConfig $rectorConfig): void {
         SetList::EARLY_RETURN,
         SetList::TYPE_DECLARATION,
     ]);
+
+    $rectorConfig->importNames();
 };

--- a/src/Builder/SluggableBuilder.php
+++ b/src/Builder/SluggableBuilder.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Khalyomede\EloquentUuidSlug\Builder;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @extends Builder<Model>
+ */
+final class SluggableBuilder extends Builder
+{
+    public function withSlug(string $slug): self
+    {
+        /** @phpstan-ignore-next-line Call to an undefined method Illuminate\Database\Eloquent\Model::slugColumn(). */
+        $this->where($this->model->slugColumn(), $slug);
+
+        return $this;
+    }
+
+    public function findBySlug(string $slug): ?Model
+    {
+        return $this->firstBySlug($slug);
+    }
+
+    public function findBySlugOrFail(string $slug): Model
+    {
+        return $this->firstBySlugOrFail($slug);
+    }
+
+    public function firstBySlug(string $slug): ?Model
+    {
+        /** @phpstan-ignore-next-line Call to an undefined method Illuminate\Database\Eloquent\Model::slugColumn(). */
+        return $this->where($this->model->slugColumn(), $slug)->first();
+    }
+
+    public function firstBySlugOrFail(string $slug): Model
+    {
+        /** @phpstan-ignore-next-line Call to an undefined method Illuminate\Database\Eloquent\Model::slugColumn(). */
+        return $this->where($this->model->slugColumn(), $slug)->firstOrFail();
+    }
+}

--- a/tests/Models/Cart.php
+++ b/tests/Models/Cart.php
@@ -19,14 +19,14 @@ final class Cart extends Model
 
     protected $guarded = [];
 
+    public function slugColumn(): string
+    {
+        return 'code';
+    }
+
     protected function slugWithDashes(): bool
     {
         return true;
-    }
-
-    protected function slugColumn(): string
-    {
-        return 'code';
     }
 
     protected static function newFactory(): CartFactory

--- a/tests/Models/Post.php
+++ b/tests/Models/Post.php
@@ -4,6 +4,7 @@ namespace Tests\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Khalyomede\EloquentUuidSlug\Sluggable;
 use Tests\Database\Factories\PostFactory;
 

--- a/tests/Models/Product.php
+++ b/tests/Models/Product.php
@@ -4,6 +4,7 @@ namespace Tests\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Khalyomede\EloquentUuidSlug\Sluggable;
 use Tests\Database\Factories\ProductFactory;
 
@@ -18,6 +19,14 @@ final class Product extends Model
     use Sluggable;
 
     protected $guarded = [];
+
+    /**
+     * @return HasMany<Rating>
+     */
+    public function ratings(): HasMany
+    {
+        return $this->hasMany(Rating::class);
+    }
 
     protected function slugWithDashes(): bool
     {

--- a/tests/Models/Rating.php
+++ b/tests/Models/Rating.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Khalyomede\EloquentUuidSlug\Sluggable;
+use Tests\Database\Factories\RatingFactory;
+
+final class Rating extends Model
+{
+    use HasFactory;
+    use Sluggable;
+
+    /**
+     * @return BelongsTo<Product, self>
+     */
+    public function product(): BelongsTo
+    {
+        return $this->belongsTo(Product::class);
+    }
+
+    protected static function newFactory(): RatingFactory
+    {
+        return RatingFactory::new();
+    }
+}

--- a/tests/database/factories/RatingFactory.php
+++ b/tests/database/factories/RatingFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Tests\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Tests\Models\Product;
+use Tests\Models\Rating;
+
+/**
+ * @extends Factory<Rating>
+ */
+final class RatingFactory extends Factory
+{
+    protected $model = Rating::class;
+
+    /**
+     * @return array{product_id: Factory<Product>, content: string}
+     */
+    public function definition(): array
+    {
+        return [
+            'product_id' => Product::factory(),
+            'content' => $this->faker->text(),
+        ];
+    }
+}

--- a/tests/database/migrations/202301151849_create_ratings_table.php
+++ b/tests/database/migrations/202301151849_create_ratings_table.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Database\Migrations;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Tests\Models\Product;
+use Tests\Models\Rating;
+
+return new class () extends Migration {
+    public function up(): void
+    {
+        Schema::create('ratings', function (Blueprint $table): void {
+            $table->id();
+
+            Rating::addSlugColumn($table);
+
+            $table->foreignIdFor(Product::class)->constrained();
+            $table->string('content');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::drop('ratings');
+    }
+};


### PR DESCRIPTION
## Added

- New `Sluggable::firstBySlug()` and `Sluggable::firstBySlugOrFail()`

## Fixed

- Unable to chain scope methods `Sluggable::findBySlug()` and `Sluggable::findBySlugOrFail()` after Built-in Query builder scopes
- Unable to call `Sluggable::findBySlug()` nor `Sluggable::findBySlugOrFail()` on HasMany relationship

## Breaking

- `protected function slugColumn()` signature is now public `public function slugColumn()`